### PR TITLE
password hardening: Fix the test to support Debian 12

### DIFF
--- a/tests/passw_hardening/conftest.py
+++ b/tests/passw_hardening/conftest.py
@@ -71,9 +71,11 @@ def clean_passw_en_dis_policies(duthosts, enum_rand_one_per_hwsku_hostname):
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
     passw_hardening_utils.config_user(duthost=duthost, username=passw_hardening_utils.USERNAME_SIMPLE_0, mode='del')
     passw_hardening_utils.config_user(duthost=duthost, username=passw_hardening_utils.USERNAME_SIMPLE_1, mode='del')
+    passw_hardening_utils.config_user(duthost=duthost, username=passw_hardening_utils.USERNAME_SIMPLE_2, mode='del')
     passw_hardening_utils.config_user(duthost=duthost, username=passw_hardening_utils.USERNAME_STRONG, mode='del')
     duthost.shell('sed -i /^'+passw_hardening_utils.USERNAME_SIMPLE_0+':/d /etc/security/opasswd')
     duthost.shell('sed -i /^'+passw_hardening_utils.USERNAME_SIMPLE_1+':/d /etc/security/opasswd')
+    duthost.shell('sed -i /^'+passw_hardening_utils.USERNAME_SIMPLE_2+':/d /etc/security/opasswd')
     duthost.shell('sed -i /^'+passw_hardening_utils.USERNAME_STRONG+':/d /etc/security/opasswd')
 
 

--- a/tests/passw_hardening/passw_hardening_utils.py
+++ b/tests/passw_hardening/passw_hardening_utils.py
@@ -25,6 +25,7 @@ PAM_PASSWORD_CONF = "/etc/pam.d/common-password"
 USERNAME_STRONG = 'user_strong_test'
 USERNAME_SIMPLE_0 = 'user_simple_0_test'
 USERNAME_SIMPLE_1 = 'user_simple_1_test'
+USERNAME_SIMPLE_2 = 'user_simple_2_test'
 USERNAME_ONE_POLICY = 'user_one_policy_test'
 USERNAME_AGE = 'user_test'
 USERNAME_HISTORY = 'user_history_test'

--- a/tests/passw_hardening/sample/passw_hardening_digits/common-password
+++ b/tests/passw_hardening/sample/passw_hardening_digits/common-password
@@ -24,7 +24,7 @@
 
 # here are the per-package modules (the "Primary" block)
 
-password    requisite      pam_cracklib.so retry=3 maxrepeat=0 minlen=1 ucredit=0 lcredit=0 dcredit=-1 ocredit=0  enforce_for_root
+password    requisite      pam_pwquality.so retry=3 maxrepeat=0 minlen=1 ucredit=0 lcredit=0 dcredit=-1 ocredit=0  enforce_for_root dictcheck=0
 
 password    required       pam_pwhistory.so remember=12 use_authtok enforce_for_root
 

--- a/tests/passw_hardening/sample/passw_hardening_enable/common-password
+++ b/tests/passw_hardening/sample/passw_hardening_enable/common-password
@@ -24,7 +24,7 @@
 
 # here are the per-package modules (the "Primary" block)
 
-password    requisite      pam_cracklib.so retry=3 maxrepeat=0 minlen=8 ucredit=-1 lcredit=-1 dcredit=-1 ocredit=-1 reject_username enforce_for_root
+password    requisite      pam_pwquality.so retry=3 maxrepeat=0 minlen=8 ucredit=-1 lcredit=-1 dcredit=-1 ocredit=-1 reject_username enforce_for_root dictcheck=0
 
 password    required       pam_pwhistory.so remember=12 use_authtok enforce_for_root
 

--- a/tests/passw_hardening/sample/passw_hardening_history/common-password
+++ b/tests/passw_hardening/sample/passw_hardening_history/common-password
@@ -24,7 +24,7 @@
 
 # here are the per-package modules (the "Primary" block)
 
-password    requisite      pam_cracklib.so retry=3 maxrepeat=0 minlen=8 ucredit=0 lcredit=0 dcredit=-1 ocredit=0  enforce_for_root
+password    requisite      pam_pwquality.so retry=3 maxrepeat=0 minlen=8 ucredit=0 lcredit=0 dcredit=-1 ocredit=0  enforce_for_root dictcheck=0
 
 password    required       pam_pwhistory.so remember=10 use_authtok enforce_for_root
 

--- a/tests/passw_hardening/sample/passw_hardening_lower_letter/common-password
+++ b/tests/passw_hardening/sample/passw_hardening_lower_letter/common-password
@@ -24,7 +24,7 @@
 
 # here are the per-package modules (the "Primary" block)
 
-password    requisite      pam_cracklib.so retry=3 maxrepeat=0 minlen=1 ucredit=0 lcredit=-1 dcredit=0 ocredit=0  enforce_for_root
+password    requisite      pam_pwquality.so retry=3 maxrepeat=0 minlen=1 ucredit=0 lcredit=-1 dcredit=0 ocredit=0  enforce_for_root dictcheck=0
 
 password    required       pam_pwhistory.so remember=10 use_authtok enforce_for_root
 

--- a/tests/passw_hardening/sample/passw_hardening_min_len/common-password
+++ b/tests/passw_hardening/sample/passw_hardening_min_len/common-password
@@ -24,7 +24,7 @@
 
 # here are the per-package modules (the "Primary" block)
 
-password    requisite      pam_cracklib.so retry=3 maxrepeat=0 minlen=8 ucredit=0 lcredit=0 dcredit=-1 ocredit=0  enforce_for_root
+password    requisite      pam_pwquality.so retry=3 maxrepeat=0 minlen=8 ucredit=0 lcredit=0 dcredit=-1 ocredit=0  enforce_for_root dictcheck=0
 
 password    required       pam_pwhistory.so remember=10 use_authtok enforce_for_root
 

--- a/tests/passw_hardening/sample/passw_hardening_reject_user_passw_match/common-password
+++ b/tests/passw_hardening/sample/passw_hardening_reject_user_passw_match/common-password
@@ -24,7 +24,7 @@
 
 # here are the per-package modules (the "Primary" block)
 
-password    requisite      pam_cracklib.so retry=3 maxrepeat=0 minlen=1 ucredit=0 lcredit=0 dcredit=0 ocredit=0 reject_username enforce_for_root
+password    requisite      pam_pwquality.so retry=3 maxrepeat=0 minlen=1 ucredit=0 lcredit=0 dcredit=0 ocredit=0 reject_username enforce_for_root dictcheck=0
 
 password    required       pam_pwhistory.so remember=10 use_authtok enforce_for_root
 

--- a/tests/passw_hardening/sample/passw_hardening_special_letter/common-password
+++ b/tests/passw_hardening/sample/passw_hardening_special_letter/common-password
@@ -24,7 +24,7 @@
 
 # here are the per-package modules (the "Primary" block)
 
-password    requisite      pam_cracklib.so retry=3 maxrepeat=0 minlen=1 ucredit=0 lcredit=0 dcredit=0 ocredit=-1  enforce_for_root
+password    requisite      pam_pwquality.so retry=3 maxrepeat=0 minlen=1 ucredit=0 lcredit=0 dcredit=0 ocredit=-1  enforce_for_root dictcheck=0
 
 password    required       pam_pwhistory.so remember=10 use_authtok enforce_for_root
 

--- a/tests/passw_hardening/sample/passw_hardening_upper_letter/common-password
+++ b/tests/passw_hardening/sample/passw_hardening_upper_letter/common-password
@@ -24,7 +24,7 @@
 
 # here are the per-package modules (the "Primary" block)
 
-password    requisite      pam_cracklib.so retry=3 maxrepeat=0 minlen=1 ucredit=-1 lcredit=0 dcredit=0 ocredit=0  enforce_for_root
+password    requisite      pam_pwquality.so retry=3 maxrepeat=0 minlen=1 ucredit=-1 lcredit=0 dcredit=0 ocredit=0  enforce_for_root dictcheck=0
 
 password    required       pam_pwhistory.so remember=10 use_authtok enforce_for_root
 

--- a/tests/passw_hardening/test_passw_hardening.py
+++ b/tests/passw_hardening/test_passw_hardening.py
@@ -213,6 +213,8 @@ def test_passw_hardening_en_dis_policies(duthosts, enum_rand_one_per_hwsku_hostn
     """
     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
 
+    # PW hardening disabled
+
     # create user with weak passw when passw policies are disable.
     passw_hardening_ob_pre = passw_hardening_utils.PasswHardening(state='disabled')
 
@@ -220,13 +222,14 @@ def test_passw_hardening_en_dis_policies(duthosts, enum_rand_one_per_hwsku_hostn
     passw_hardening_utils.config_and_review_policies(duthost, passw_hardening_ob_pre,
                                                      passw_hardening_utils.PAM_PASSWORD_CONF_DEFAULT_EXPECTED)
 
-    simple_passw_0 = '12345678'
-    chpasswd_cmd = config_user_and_passw(duthost, passw_hardening_utils.USERNAME_SIMPLE_0, simple_passw_0)
+    simple_passw_digits = '12345678'
+    chpasswd_cmd = config_user_and_passw(duthost, passw_hardening_utils.USERNAME_SIMPLE_0, simple_passw_digits)
 
     pytest_assert(chpasswd_cmd['rc'] == SUCCESS_CODE,
                   "Fail: expected: username={} to be added with weak passw={}, because passw hardening disabled"
-                  .format(passw_hardening_utils.USERNAME_SIMPLE_0, simple_passw_0))
+                  .format(passw_hardening_utils.USERNAME_SIMPLE_0, simple_passw_digits))
 
+    # PW hardening enabled
     passw_hardening_ob = passw_hardening_utils.PasswHardening(state='enabled')
 
     # config one policy, check show CLI, test policy configured in switch
@@ -234,12 +237,11 @@ def test_passw_hardening_en_dis_policies(duthosts, enum_rand_one_per_hwsku_hostn
                                                      passw_hardening_utils.PAM_PASSWORD_CONF_EXPECTED)
 
     # ~~ test user with weak passw (only digits) expecting to fail (bad flow) ~~
-    simple_passw_1 = '12345678'
-    chpasswd_cmd = config_user_and_passw(duthost, passw_hardening_utils.USERNAME_SIMPLE_1, simple_passw_1)
+    chpasswd_cmd = config_user_and_passw(duthost, passw_hardening_utils.USERNAME_SIMPLE_1, simple_passw_digits)
 
-    pytest_assert("BAD PASSWORD: it is too simplistic/systematic" in chpasswd_cmd['stderr'],
+    pytest_assert("BAD PASSWORD" in chpasswd_cmd['stderr'],
                   "Fail: username='{}' with simple password='{}' was set, even though, strong policy configured"
-                  .format(passw_hardening_utils.USERNAME_SIMPLE_1, simple_passw_1))
+                  .format(passw_hardening_utils.USERNAME_SIMPLE_1, simple_passw_digits))
 
     # ~~ test user with strong password (digits, lower class, upper class, special class) ~~
     strong_passw = 'Nvi_d_ia_2020'
@@ -249,25 +251,18 @@ def test_passw_hardening_en_dis_policies(duthosts, enum_rand_one_per_hwsku_hostn
                   "Fail creating user: username='{}' with strong password='{}'"
                   .format(passw_hardening_utils.USERNAME_STRONG, strong_passw))
 
-    # clean new users
-    userdel_cmd = passw_hardening_utils.config_user(duthost=duthost,
-                                                    username=passw_hardening_utils.USERNAME_SIMPLE_1, mode='del')
-
-    pytest_assert(userdel_cmd['rc'] == SUCCESS_CODE,
-                  "Fail: users: '{}'  was not deleted correctly".format(userdel_cmd['stderr']))
-
-    # disable feature
+    # PW hardening disabled
     passw_hardening_dis_ob = passw_hardening_utils.PasswHardening(state='disabled')
     passw_hardening_utils.config_and_review_policies(duthost, passw_hardening_dis_ob,
                                                      passw_hardening_utils.PAM_PASSWORD_CONF_DEFAULT_EXPECTED)
 
     # ~~ test feature disabled: by trying to create a new user with a weak passw
     # after feature disabled expecting to success.
-    chpasswd_cmd = config_user_and_passw(duthost, passw_hardening_utils.USERNAME_SIMPLE_1, simple_passw_1)
+    chpasswd_cmd = config_user_and_passw(duthost, passw_hardening_utils.USERNAME_SIMPLE_2, simple_passw_digits)
 
     pytest_assert(chpasswd_cmd['rc'] == SUCCESS_CODE,
                   "Fail: expected: username={} to be added with weak passw={}, because passw hardening disabled"
-                  .format(passw_hardening_utils.USERNAME_SIMPLE_1, simple_passw_1))
+                  .format(passw_hardening_utils.USERNAME_SIMPLE_2, simple_passw_digits))
 
 
 def test_passw_hardening_history(duthosts, enum_rand_one_per_hwsku_hostname, clean_passw_policies, clean_passw_history):
@@ -412,6 +407,7 @@ def test_passw_hardening_len_min(duthosts, enum_rand_one_per_hwsku_hostname,
                   .format(passw_hardening_utils.USERNAME_LEN_MIN, passw_test))
 
     # --- Bad Flow ---
+    LEN_MIN = '10'
     # set new passw hardening policies values
     passw_hardening_ob_len_min_big = passw_hardening_utils.PasswHardening(state='enabled',
                                                                           expiration=expiration,
@@ -432,7 +428,7 @@ def test_passw_hardening_len_min(duthosts, enum_rand_one_per_hwsku_hostname,
     # test settig smaller passw than config
     chpasswd_cmd = change_password(duthost, passw_bad_test, passw_hardening_utils.USERNAME_LEN_MIN)
 
-    pytest_assert('BAD PASSWORD: is too simple' in chpasswd_cmd['stderr'],
+    pytest_assert('BAD PASSWORD: The password is shorter than '+LEN_MIN+' characters' in chpasswd_cmd['stderr'],
                   "Fail : password='{}' was set with an small len than the policy, even though, it was configured"
                   .format(passw_bad_test))
 
@@ -449,7 +445,7 @@ def test_passw_hardening_policies_digits(duthosts, enum_rand_one_per_hwsku_hostn
     expiration = check_expiration_value(duthost, 100)
     passw_test = '19892022'
     passw_bad_test = 'b_a_d_passw_no_digs'
-    passw_exp_error = 'BAD PASSWORD: is too simple'
+    passw_exp_error = 'BAD PASSWORD: The password contains less than 1 digits'
 
     # set new passw hardening policies values
     passw_hardening_ob = passw_hardening_utils.PasswHardening(state='enabled',
@@ -479,7 +475,7 @@ def test_passw_hardening_policies_lower_class(duthosts, enum_rand_one_per_hwsku_
     expiration = check_expiration_value(duthost, 10)
     passw_test = 'n_v_d_i_a'
     passw_bad_test = 'BADFLOWNOLOWERLETTERS'
-    passw_exp_error = 'BAD PASSWORD: is too simple'
+    passw_exp_error = 'BAD PASSWORD: The password contains less than 1 lowercase letters'
 
     # set new passw hardening policies values
     passw_hardening_ob = passw_hardening_utils.PasswHardening(state='enabled',
@@ -509,7 +505,7 @@ def test_passw_hardening_policies_upper_class(duthosts, enum_rand_one_per_hwsku_
     expiration = check_expiration_value(duthost, 10)
     passw_test = 'NVI_DI_A_UP#'
     passw_bad_test = 'l_o_w_l_#_e#t1'
-    passw_exp_error = 'BAD PASSWORD: is too simple'
+    passw_exp_error = 'BAD PASSWORD: The password contains less than 1 uppercase letters'
 
     # set new passw hardening policies values
     passw_hardening_ob = passw_hardening_utils.PasswHardening(state='enabled',
@@ -539,7 +535,7 @@ def test_passw_hardening_policies_special_class(duthosts, enum_rand_one_per_hwsk
     expiration = check_expiration_value(duthost, 10)
     passw_test = 'nvipashar_'
     passw_bad_test = 'no11spec'
-    passw_exp_error = 'BAD PASSWORD: is too simple'
+    passw_exp_error = 'BAD PASSWORD: The password contains less than 1 non-alphanumeric characters'
 
     # set new passw hardening policies values
     passw_hardening_ob = passw_hardening_utils.PasswHardening(state='enabled',
@@ -568,7 +564,7 @@ def test_passw_hardening_policy_reject_user_passw_match(duthosts, enum_rand_one_
     expiration = check_expiration_value(duthost, 10)
     passw_test = '19892022'
     passw_bad_test = passw_hardening_utils.USERNAME_ONE_POLICY
-    passw_exp_error = 'BAD PASSWORD: contains the user name in some form'
+    passw_exp_error = 'BAD PASSWORD: The password contains the user name in some form'
 
     # set new passw hardening policies values
     passw_hardening_ob = passw_hardening_utils.PasswHardening(state='enabled',


### PR DESCRIPTION
Fix the test to support Debian 12 by replacing cracklib usage with pwquality library
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Fix as part of Debian 12 support in SONiC
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [X ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [ ] 202305

### Approach
#### What is the motivation for this PR?
Fix Password Hardening tests to support Debian 12 modifications.
#### How did you do it?
replace usage of pam_cracklib.so with pam_pwquality.so
#### How did you verify/test it?
run these PW hardening tests with the branch 112023 which based Debian 12
#### Any platform specific information?
no
#### Supported testbed topology if it's a new test case?
no
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
